### PR TITLE
Replaced SERVICESTATE for HOSTSTATE

### DIFF
--- a/nagios/commands.cfg
+++ b/nagios/commands.cfg
@@ -4,7 +4,7 @@
 
 define command{
     command_name    notify-host-by-txt
-    command_line    /usr/bin/php /path/to/sendTxtMsg/sendTxtMsg.php "$CONTACTPAGER$" "Nagios Alert\nType: $NOTIFICATIONTYPE$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\nWhen: $LONGDATETIME$"
+    command_line    /usr/bin/php /path/to/sendTxtMsg/sendTxtMsg.php "$CONTACTPAGER$" "Nagios Alert\nType: $NOTIFICATIONTYPE$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $HOSTSTATE$\nWhen: $LONGDATETIME$"
 }
 
 define command{


### PR DESCRIPTION
Replaced SERVICESTATE macro for HOSTSTATE for the notify-host-by-txt command.
